### PR TITLE
SOA-503 — Configurer le stockage durable des rapports d'erreurs

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -73,7 +73,10 @@ BACON_PROVIDER_API_JAVA_OPTIONS="-XX:MaxRAMPercentage=90"
 ##############################################
 #   LOGSKBART API
 ##############################################
+# Chemin hôte monté dans /tempLog/ (ex. /applis/bacon/toLoad sur diplo2)
 LOGSKBART_API_PATH_TSVFILE=
+# Chemin interne utilisé par logskbart-api pour créer le sous-dossier bad/
+ABES_PATH_TO_REPORTS=/tempLog/
 ABES_NBTHREAD=
 LOGSKBART_API_HTTP_PORT=
 LOGSKBART_KIBANA_PORT=

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ target/
 *.iws
 *.iml
 *.ipr
-*.env
+.env*
+!.env-dist
 
 ### NetBeans ###
 /nbproject/private/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -306,6 +306,7 @@ services:
       # voir le contenu des application-xxx.properties embarqués dans le code sources
       ABES_KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS}
       ABES_NBTHREAD: ${ABES_NBTHREAD}
+      ABES_PATH_TO_REPORTS: ${ABES_PATH_TO_REPORTS:-/tempLog/}
       MAIL_WS_URL: ${MAIL_WS_URL}
       SPRING_ELASTICSEARCH_URIS: http://logskbart-elasticsearch:9200
       MAIL_WS_RECIPIENT: ${MAIL_WS_RECIPIENT_KBART_2_BACON}


### PR DESCRIPTION
## Pourquoi

`logskbart-api` conserve désormais les rapports `.bad` dans un sous-dossier durable. Le chemin de rapports doit être transmis explicitement au conteneur et correspondre au volume monté depuis diplo2.

## Modifications

- ajoute `ABES_PATH_TO_REPORTS=/tempLog/` dans le modèle d'environnement ;
- transmet cette propriété au service `logskbart-api` avec `/tempLog/` comme valeur par défaut ;
- documente que `LOGSKBART_API_PATH_TSVFILE` doit pointer vers le chemin hôte, par exemple `/applis/bacon/toLoad` sur diplo2.

## Impact

Le sous-dossier `/tempLog/bad/` créé par l'application est conservé sur l'hôte dans `/applis/bacon/toLoad/bad/` lorsque le montage diplo2 est configuré.

## Validation

- `docker compose config --no-interpolate --quiet`
- validation réussie avec Docker Compose v5.0.2
